### PR TITLE
Feature/migration tinysegmenter to linderawasm

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  webpack(config) {
+    config.experiments = { ...config.experiments, asyncWebAssembly: true };
+
+    config.module.rules.push({
+      test: /\.wasm$/,
+      type: "webassembly/async",
+    });
+
+    config.resolve.extensions.push(".wasm");
+
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,13 +17,13 @@
         "cytoscape-dagre": "^2.5.0",
         "cytoscape-elk": "^2.3.0",
         "cytoscape-klay": "^3.1.4",
+        "lindera-wasm": "^0.43.1",
         "lucide-react": "^0.511.0",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-cytoscapejs": "^2.0.0",
         "react-dom": "^19.0.0",
-        "stopword": "^3.1.4",
-        "tiny-segmenter": "^0.2.0"
+        "stopword": "^3.1.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -4354,6 +4354,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lindera-wasm": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/lindera-wasm/-/lindera-wasm-0.43.1.tgz",
+      "integrity": "sha512-NiEokq2A4jydKBmjiAgDQHcMfKRPT5WZLopzQKp+22yprM18IGOEs/EF3YJtUBsI1lAgypgLPsbAbskqeP0r+Q==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5592,12 +5598,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/tiny-segmenter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-segmenter/-/tiny-segmenter-0.2.0.tgz",
-      "integrity": "sha512-m+aTJQ/CUBKurLaJRpLmJiwcL+Gpkzft5ZYnRU9AkuO45Y/k/2iJmuLEbN1XLrq6N3kDVyIUCCeqRzQx0feBag==",
-      "license": "SEE LICENSE IN http://chasen.org/~taku/software/TinySegmenter/LICENCE.txt"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -8782,6 +8782,11 @@
       "dev": true,
       "optional": true
     },
+    "lindera-wasm": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/lindera-wasm/-/lindera-wasm-0.43.1.tgz",
+      "integrity": "sha512-NiEokq2A4jydKBmjiAgDQHcMfKRPT5WZLopzQKp+22yprM18IGOEs/EF3YJtUBsI1lAgypgLPsbAbskqeP0r+Q=="
+    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -9596,11 +9601,6 @@
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
       }
-    },
-    "tiny-segmenter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-segmenter/-/tiny-segmenter-0.2.0.tgz",
-      "integrity": "sha512-m+aTJQ/CUBKurLaJRpLmJiwcL+Gpkzft5ZYnRU9AkuO45Y/k/2iJmuLEbN1XLrq6N3kDVyIUCCeqRzQx0feBag=="
     },
     "tinyglobby": {
       "version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "cytoscape-dagre": "^2.5.0",
     "cytoscape-elk": "^2.3.0",
     "cytoscape-klay": "^3.1.4",
+    "lindera-wasm": "^0.43.1",
     "lucide-react": "^0.511.0",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-cytoscapejs": "^2.0.0",
     "react-dom": "^19.0.0",
-    "stopword": "^3.1.4",
-    "tiny-segmenter": "^0.2.0"
+    "stopword": "^3.1.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/notion/list/route.ts
+++ b/src/app/api/notion/list/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
         "Notion-Version": "2022-06-28",
       },
       body: JSON.stringify({ 
-        page_size: 100,
+        page_size: 5,
         sorts: [{ property: "Stacked at", direction: "ascending" }],
       }),
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,8 +105,8 @@ export default function Page() {
   }, [selectedDbId]);
 
   /* ───── キーワード抽出ボタン ───────────── */
-  const handleExtract = () => {
-    const enriched = addPageKeywords(items, 10);
+  const handleExtract = async() => {
+    const enriched = await addPageKeywords(items, 10);
     setSelectedProps((prev) =>
       prev.includes(KW_PROP) ? prev : [...prev, KW_PROP]
     );

--- a/src/lib/keyword.ts
+++ b/src/lib/keyword.ts
@@ -1,10 +1,21 @@
-import TinySegmenter from "tiny-segmenter";
-import { removeStopwords, jpn } from "stopword";
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-explicit-any */
 
-// 追加で弾きたい語
+/* -------------------------------------------------------------
+ * lib/keyword.ts  ―  Lindera-wasm版キーワード抽出ユーティリティ
+ * -------------------------------------------------------------
+ * 変更点
+ * 1.  tiny-segmenter  →  lindera-wasm（WASM 形態素解析器）
+ * 2.  初期化は非同期なので、公開 API も Promise ベースに
+ * 3.  既存呼び出しコードは `await` で包むだけで互換
+ * ---------------------------------------------------------- */
+
+import { removeStopwords, jpn } from "stopword";
+import type { Tokenizer } from "lindera-wasm";
+
+/* 追加で弾きたい語 */
 const CUSTOM_STOP = new Set([
   "系",
-  "x",     // tweet の " / X" など
+  "x",
   "rt",
   "on",
   "|",
@@ -14,57 +25,82 @@ const CUSTOM_STOP = new Set([
   "“",
 ]);
 
-const segmenter = new TinySegmenter();
+/* ─────────── tokenizer singleton ─────────── */
+let tokenizerPromise: Promise<Tokenizer> | null = null;
 
-/** 0) タイトル正規化 */
+async function getTokenizer(): Promise<Tokenizer> {
+  if (tokenizerPromise) return tokenizerPromise;
+
+  tokenizerPromise = (async () => {
+    const { TokenizerBuilder } = await import("lindera-wasm");
+
+    const builder = new TokenizerBuilder();
+    builder.setDictionaryKind("ipadic");
+    builder.setMode("normal");
+    builder.appendCharacterFilter("unicode_normalize", { kind: "nfkc" });
+    builder.appendTokenFilter("japanese_compound_word", {
+        "kind": "ipadic",
+        "tags": [
+            "名詞,数"
+        ],
+        "new_tag": "名詞,数"
+    });
+
+    return builder.build();
+  })();
+
+  return tokenizerPromise;
+}
+
+/* ─────────── 正規化 ─────────── */
 function normalize(text: string): string {
   return (
     text
-      // ── URL・ツイッターの on X: ～ を除去
       .replace(/https?:\/\/\S+/g, "")
       .replace(/on\s+X:?/gi, "")
-      // ── twitter の "ユーザー名 |肩書き:" を削る
       .replace(/^[^:|]+[:|]\s*/, "")
-      // ── カッコ内の日付や絵文字を削る
       .replace(/\([^)]*\)$/g, "")
-      // ── 記号をスペースに
       .replace(/[「」“”"『』【】\[\](),.:|\/]/g, " ")
-      // ── 全角英数を半角に
       .replace(/[Ａ-Ｚａ-ｚ０-９]/g, (s) =>
-        String.fromCharCode(s.charCodeAt(0) - 0xfee0)
+        String.fromCharCode(s.charCodeAt(0) - 0xfee0),
       )
       .trim()
   );
 }
 
-/** 1) 分かち書き */
-export function tokenize(text: string): string[] {
-  const tokens = segmenter.segment(normalize(text));
+/* ─────────── 分かち書き ─────────── */
+export async function tokenize(text: string): Promise<string[]> {
+  const tokenizer = await getTokenizer();
+  const tokens = tokenizer.tokenize(normalize(text));
 
-  return tokens
-    .map((t) => t.trim())
-    .filter(Boolean)
-    // アルファベットは小文字化
-    .map((t) => (/^[A-Za-z]+$/.test(t) ? t.toLowerCase() : t));
+  interface LinderaToken {
+    get(key: string): string | undefined;
+  }
+
+  return (tokens as LinderaToken[])
+    .map((t: LinderaToken) => String(t.get("text") || "").trim())
+    .filter((t: string) => Boolean(t))
+    .map((t: string) => (/^[A-Za-z]+$/.test(t) ? t.toLowerCase() : t));
 }
 
-/** 2) キーワード抽出 */
-export function extractKeywords(title: string, topN = 5): string[] {
-  const tokens = tokenize(title);
+/* ─────────── キーワード抽出 ─────────── */
+export async function extractKeywords(
+  title: string,
+  topN = 5,
+): Promise<string[]> {
+  const tokens = await tokenize(title);
 
-  // ストップワード & ヒューリスティック除去
   const filtered = removeStopwords(tokens, jpn).filter((t) => {
-    if (CUSTOM_STOP.has(t)) return false;          // カスタム NG
-    if (/^[\p{P}\p{S}]+$/u.test(t)) return false;  // 記号のみ
-    if (/^\d+$/.test(t)) return false;             // 数字のみ
-    if (t.length === 1) return false;              // 1 文字語
+    if (CUSTOM_STOP.has(t)) return false;
+    if (/^[\p{P}\p{S}]+$/u.test(t)) return false;
+    if (/^\d+$/.test(t)) return false;
+    if (t.length === 1) return false;
     return true;
   });
 
-  // 頻度＋長さスコア
   const score: Record<string, number> = {};
   filtered.forEach((w) => {
-    score[w] = (score[w] ?? 0) + 1 + w.length * 0.2; // 長い語を僅かに加点
+    score[w] = (score[w] ?? 0) + 1 + w.length * 0.2;
   });
 
   return Object.entries(score)
@@ -73,12 +109,15 @@ export function extractKeywords(title: string, topN = 5): string[] {
     .map(([w]) => w);
 }
 
-/** 3) ページ配列に keywords を追加 */
-export function addPageKeywords<
-  T extends { id: string; title: string }
->(pages: T[], topN = 5): (T & { keywords: string[] })[] {
-  return pages.map((p) => ({
-    ...p,
-    keywords: extractKeywords(p.title, topN),
-  }));
+/* ─────────── ページに keywords を付与 ─────────── */
+export async function addPageKeywords<
+  T extends { id: string; title: string },
+>(pages: T[], topN = 5): Promise<(T & { keywords: string[] })[]> {
+  const enriched = await Promise.all(
+    pages.map(async (p) => ({
+      ...p,
+      keywords: await extractKeywords(p.title, topN),
+    })),
+  );
+  return enriched;
 }


### PR DESCRIPTION
**変更点**
1.  tiny-segmenter  →  lindera-wasm（WASM 形態素解析器）
2.  初期化は非同期なので、公開 API も Promise ベースに
3.  既存呼び出しコードは `await` で包むだけで互換