### PR TITLE
Add Vitest setup and unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@notionhq/client": "^3.1.3",

--- a/tests/unit/graph.test.ts
+++ b/tests/unit/graph.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { slug, buildGraph } from '@/lib/cytoscape/graph'
+
+const samplePages = [
+  { id: '1', title: 'Page One', keywords: ['Alpha', 'Beta'], tags: ['Tag1'] },
+  { id: '2', title: 'Page Two', keywords: ['Beta'], tags: ['Tag2', 'Tag3'] },
+]
+
+describe('slug', () => {
+  it('creates kebab-case ids', () => {
+    expect(slug('Hello World!')).toBe('hello-world')
+    expect(slug(' Foo_Bar ')).toBe('foo_bar')
+  })
+})
+
+describe('buildGraph', () => {
+  it('builds page-only graph by default', () => {
+    const g = buildGraph(samplePages)
+    expect(g.nodes).toHaveLength(2)
+    expect(g.edges).toHaveLength(0)
+  })
+
+  it('includes keywords when selected', () => {
+    const g = buildGraph(samplePages, { selectedProps: ['__keywords'] })
+    // 2 pages + 2 keywords (Alpha,Beta) unique
+    expect(g.nodes.length).toBe(4)
+    // edges: page->keyword
+    expect(g.edges.length).toBe(3)
+  })
+
+  it('includes property values when selected', () => {
+    const g = buildGraph(samplePages, { selectedProps: ['tags'] })
+    // pages + tags (3 unique)
+    expect(g.nodes.length).toBe(5)
+    expect(g.edges.length).toBe(3)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- configure Vitest with path aliases
- add basic graph tests
- expose `npm test` script

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683e841c7b6c8330b3e7b12018b4ed0c