### PR TITLE
Expand tests

### DIFF
--- a/tests/unit/graph.test.ts
+++ b/tests/unit/graph.test.ts
@@ -11,6 +11,11 @@ describe('slug', () => {
     expect(slug('Hello World!')).toBe('hello-world')
     expect(slug(' Foo_Bar ')).toBe('foo_bar')
   })
+
+  it('normalizes accented characters', () => {
+    expect(slug('ÀÉÎÖÜ')).toBe('a-e-i-o-u')
+    expect(slug('café — bar')).toBe('cafe-bar')
+  })
 })
 
 describe('buildGraph', () => {
@@ -33,5 +38,15 @@ describe('buildGraph', () => {
     // pages + tags (3 unique)
     expect(g.nodes.length).toBe(5)
     expect(g.edges.length).toBe(3)
+  })
+
+  it('deduplicates keywords and property values across pages', () => {
+    const pages = [
+      { id: '1', title: 'First', keywords: ['Alpha', 'Beta'], tags: ['Tag1', 'Tag2'] },
+      { id: '2', title: 'Second', keywords: ['Beta', 'Gamma'], tags: ['Tag1'] },
+    ]
+    const g = buildGraph(pages, { selectedProps: ['__keywords', 'tags'] })
+    expect(g.nodes.length).toBe(7) // 2 pages + 3 keywords + 2 tags
+    expect(g.edges.length).toBe(7) // 4 keyword edges + 3 tag edges
   })
 })

--- a/tests/unit/notionToken.test.ts
+++ b/tests/unit/notionToken.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { saveNotionToken, getNotionToken, requireNotionToken, clearNotionToken } from '@/lib/notion/notionToken'
+
+// simple in-memory localStorage mock
+function createStorage() {
+  const store: Record<string, string> = {}
+  return {
+    setItem: (k: string, v: string) => { store[k] = v },
+    getItem: (k: string) => store[k] ?? null,
+    removeItem: (k: string) => { delete store[k] }
+  }
+}
+
+describe('notionToken utilities', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    // localStorage accessed both via window and global
+    const storage = createStorage()
+    // @ts-ignore
+    globalThis.window = { localStorage: storage }
+    // @ts-ignore
+    globalThis.localStorage = storage
+  })
+
+  afterEach(() => {
+    // @ts-ignore
+    delete globalThis.window
+    // @ts-ignore
+    delete globalThis.localStorage
+  })
+
+  it('saves and retrieves token', () => {
+    saveNotionToken('abc')
+    expect(getNotionToken()).toBe('abc')
+  })
+
+  it('requires token or throws', () => {
+    saveNotionToken('def')
+    expect(requireNotionToken()).toBe('def')
+    clearNotionToken()
+    expect(() => requireNotionToken()).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- increase slug and buildGraph coverage
- add tests for notion token storage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683e853eec7c8330b5a156156f22c5ba