### PR TITLE
Add PNG/JSON export for graph

### DIFF
--- a/src/components/GraphPanel.tsx
+++ b/src/components/GraphPanel.tsx
@@ -35,6 +35,27 @@ export default function GraphPanel({ pages, selectedProps }: Props) {
     onFit: () => viewRef.current?.fit(),
     onZoomIn: () => viewRef.current?.zoomIn(),
     onZoomOut: () => viewRef.current?.zoomOut(),
+    onExportPng: () => {
+      const uri = viewRef.current?.png();
+      if (!uri) return;
+      const a = document.createElement("a");
+      a.href = uri;
+      a.download = "graph.png";
+      a.click();
+    },
+    onExportJson: () => {
+      const json = viewRef.current?.json();
+      if (!json) return;
+      const blob = new Blob([JSON.stringify(json, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "graph.json";
+      a.click();
+      URL.revokeObjectURL(url);
+    },
     showEdgeLabels,
     showNodeLabels,
     onToggleEdgeLabels: () => setShowEdgeLabels((s) => !s),

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -65,6 +65,8 @@ export interface GraphViewHandle {
   zoomIn: () => void;
   zoomOut: () => void;
   setLayout: (l: LayoutName) => void;
+  png: () => string | undefined;
+  json: () => any;
 }
 
 const GraphView = forwardRef<GraphViewHandle, Props>(
@@ -81,6 +83,8 @@ const GraphView = forwardRef<GraphViewHandle, Props>(
       zoomIn: () => cyRef.current?.zoom(cyRef.current.zoom() * 1.2),
       zoomOut: () => cyRef.current?.zoom(cyRef.current.zoom() * 0.8),
       setLayout: (l: LayoutName) => cyRef.current?.layout(layouts[l]).run(),
+      png: () => cyRef.current?.png({ full: true }),
+      json: () => cyRef.current?.json(),
     }));
 
     return (

--- a/src/components/LayoutControls.tsx
+++ b/src/components/LayoutControls.tsx
@@ -9,6 +9,8 @@ import {
   RefreshCw,
   Eye,
   EyeOff,
+  Download,
+  FileJson,
 } from "lucide-react";
 import { layouts } from "./GraphView";
 
@@ -28,6 +30,8 @@ type Props = {
   onFit: () => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
+  onExportPng: () => void;
+  onExportJson: () => void;
   showEdgeLabels: boolean;
   showNodeLabels: boolean;
   onToggleEdgeLabels: () => void;
@@ -40,6 +44,8 @@ export default function LayoutControls({
   onFit,
   onZoomIn,
   onZoomOut,
+  onExportPng,
+  onExportJson,
   showEdgeLabels,
   showNodeLabels,
   onToggleEdgeLabels,
@@ -85,6 +91,16 @@ export default function LayoutControls({
             </button>
             <button onClick={onZoomOut} className={baseBtn}>
               <ZoomOut size={14} />
+            </button>
+          </div>
+
+          {/* export buttons */}
+          <div className="flex gap-2">
+            <button onClick={onExportPng} className={baseBtn}>
+              <Download size={14} /> PNG
+            </button>
+            <button onClick={onExportJson} className={baseBtn}>
+              <FileJson size={14} /> JSON
             </button>
           </div>
 


### PR DESCRIPTION
## Summary
- expose `png()` and `json()` methods from `GraphView`
- add export buttons in `LayoutControls`
- wire export handlers in `GraphPanel`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_683eba81f828833096704a339aa3a229