### PR TITLE
Add collapsible graph panels

### DIFF
--- a/src/components/NodeListPanel.tsx
+++ b/src/components/NodeListPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import { Trash } from "lucide-react";
+import { Trash, ChevronDown, ChevronRight, ListTree } from "lucide-react";
 import type { GraphViewHandle } from "./GraphView";
 
 interface NodeInfo {
@@ -14,6 +14,7 @@ interface Props {
 }
 
 export default function NodeListPanel({ viewRef }: Props) {
+  const [collapsed, setCollapsed] = useState(false);
   const [nodes, setNodes] = useState<NodeInfo[]>([]);
 
   const refresh = () => {
@@ -32,24 +33,33 @@ export default function NodeListPanel({ viewRef }: Props) {
   };
 
   return (
-    <section className="rounded-[var(--radius-card)] border border-n-gray bg-white p-3 text-sm">
-      <h2 className="mb-2 font-medium">Nodes</h2>
-      <ul className="max-h-64 space-y-1 overflow-auto">
-        {nodes.map((n) => (
-          <li key={n.id} className="flex items-center justify-between gap-2">
-            <span>
-              {n.label}
-              <span className="text-xs text-n-gray-600">({n.degree})</span>
-            </span>
-            <button
-              onClick={() => handleDelete(n.id)}
-              className="text-n-red hover:text-n-red-700"
-            >
-              <Trash size={14} />
-            </button>
-          </li>
-        ))}
-      </ul>
+    <section className="flex flex-col gap-2 rounded-[var(--radius-card)] border border-n-gray bg-white p-3 text-sm">
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex w-full items-center gap-1 font-medium"
+      >
+        {collapsed ? <ChevronRight size={18} /> : <ChevronDown size={18} />}
+        <ListTree size={18} />
+        Nodes
+      </button>
+      {!collapsed && (
+        <ul className="max-h-64 space-y-1 overflow-auto">
+          {nodes.map((n) => (
+            <li key={n.id} className="flex items-center justify-between gap-2">
+              <span>
+                {n.label}
+                <span className="text-xs text-n-gray-600">({n.degree})</span>
+              </span>
+              <button
+                onClick={() => handleDelete(n.id)}
+                className="text-n-red hover:text-n-red-700"
+              >
+                <Trash size={14} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { ChevronDown, ChevronRight, BarChart3 } from "lucide-react";
 import type { PageKW } from "@/lib/cytoscape/graph";
 import { buildGraph } from "@/lib/cytoscape/graph";
 import { computeGraphStats } from "@/lib/cytoscape/stats";
@@ -7,24 +8,36 @@ import { computeGraphStats } from "@/lib/cytoscape/stats";
 type Props = { pages: PageKW[]; selectedProps: string[] };
 
 export default function StatsPanel({ pages, selectedProps }: Props) {
+  const [collapsed, setCollapsed] = useState(false);
   const stats = useMemo(() => {
     const graph = buildGraph(pages, { selectedProps });
     return computeGraphStats(graph);
   }, [pages, selectedProps]);
 
   return (
-    <section className="rounded-[var(--radius-card)] border border-n-gray bg-white p-3 text-sm">
-      <h2 className="mb-2 font-medium">Graph Stats</h2>
-      <p>Nodes: {stats.nodeCount}</p>
-      <p>Edges: {stats.edgeCount}</p>
-      <p>Avg. Degree: {stats.avgDegree.toFixed(2)}</p>
-      <ul className="mt-2 list-disc pl-5">
-        {stats.topCentralNodes.map((n) => (
-          <li key={n.id}>
-            {n.label} <span className="text-xs text-n-gray-600">({n.degree})</span>
-          </li>
-        ))}
-      </ul>
+    <section className="flex flex-col gap-2 rounded-[var(--radius-card)] border border-n-gray bg-white p-3 text-sm">
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex w-full items-center gap-1 font-medium"
+      >
+        {collapsed ? <ChevronRight size={18} /> : <ChevronDown size={18} />}
+        <BarChart3 size={18} />
+        Graph Stats
+      </button>
+      {!collapsed && (
+        <>
+          <p>Nodes: {stats.nodeCount}</p>
+          <p>Edges: {stats.edgeCount}</p>
+          <p>Avg. Degree: {stats.avgDegree.toFixed(2)}</p>
+          <ul className="mt-2 list-disc pl-5">
+            {stats.topCentralNodes.map((n) => (
+              <li key={n.id}>
+                {n.label} <span className="text-xs text-n-gray-600">({n.degree})</span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- make StatsPanel collapsible
- make NodeListPanel collapsible

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_683ec0c065448330ac75267cd24c2095