### PR TITLE
Add dynamic property parsing

### DIFF
--- a/src/lib/notion/notionDatabase.ts
+++ b/src/lib/notion/notionDatabase.ts
@@ -24,15 +24,25 @@ export async function fetchDatabasePages(dbId: string): Promise<PageKW[]> {
       keywords: [], // 後で addPageKeywords が埋める
       createdTime: page.created_time,
       lastEditedTime: page.last_edited_time,
+      url: page.url,
     };
 
-    /* すべての multi_select / select / status を走査して配列化 */
-    Object.entries(page.properties).forEach(([key, prop]: [string, any]) => {
+    /* すべてのプロパティを走査して抽出 */
+    Object.entries(page.properties).forEach(([key, prop]) => {
       if (prop.type === "multi_select") {
-        obj[key] = prop.multi_select.map((v: any) => v.name);
-      }
-      if (prop.type === "select" && prop.select) {
-        obj[key] = [prop.select.name]; // select は単一なので配列化
+        obj[key] = (prop.multi_select as { name: string }[]).map((v) => v.name);
+      } else if (prop.type === "select" && prop.select) {
+        obj[key] = [(prop.select as { name: string }).name];
+      } else if (prop.type === "status" && prop.status) {
+        obj[key] = [(prop.status as { name: string }).name];
+      } else if (prop.type === "url" && typeof prop.url === "string") {
+        obj[key] = prop.url;
+      } else if (prop.type === "rich_text") {
+        obj[key] = (prop.rich_text as { plain_text: string }[])
+          .map((t) => t.plain_text)
+          .join("");
+      } else if (prop.type === "created_time" && prop.created_time) {
+        obj[key] = String(prop.created_time);
       }
     });
 

--- a/src/lib/notion/notionDatabase.ts
+++ b/src/lib/notion/notionDatabase.ts
@@ -17,10 +17,14 @@ export async function fetchDatabasePages(dbId: string): Promise<PageKW[]> {
 
   const json = await res.json();
 
+  console.log("Fetched pages:", json)
+
   return json.results.map((page: NotionRawPage) => {
     const obj: NotionPage = {
       id: page.id,
-      title: page.properties.Name?.title?.[0]?.plain_text ?? "Untitled",
+      title: Array.isArray(page.properties.Name?.title) && page.properties.Name.title[0]?.plain_text
+        ? page.properties.Name.title[0].plain_text
+        : "Untitled",
       keywords: [], // 後で addPageKeywords が埋める
       createdTime: page.created_time,
       lastEditedTime: page.last_edited_time,

--- a/src/lib/notion/types.ts
+++ b/src/lib/notion/types.ts
@@ -12,18 +12,20 @@ export interface NotionPage {
   title: string;
   createdTime: string;
   lastEditedTime: string;
+  url: string;
   keywords?: string[];
   [key: string]: string | string[] | undefined;
 }
 
-export interface NotionRawPage  {
+export interface NotionProperty {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface NotionRawPage {
   id: string;
   created_time: string;
   last_edited_time: string;
-  properties: {
-    [key: string]: {
-      type: string;
-      title?: { plain_text: string }[];
-    };
-  };
-};
+  url: string;
+  properties: Record<string, NotionProperty>;
+}

--- a/tests/unit/notionDatabase.test.ts
+++ b/tests/unit/notionDatabase.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { fetchDatabasePages } from '@/lib/notion/notionDatabase'
+
+function createStorage() {
+  const store: Record<string, string> = {}
+  return {
+    setItem: (k: string, v: string) => { store[k] = v },
+    getItem: (k: string) => store[k] ?? null,
+    removeItem: (k: string) => { delete store[k] }
+  }
+}
+
+describe('fetchDatabasePages', () => {
+  beforeEach(() => {
+    const storage = createStorage()
+    // @ts-ignore
+    globalThis.window = { localStorage: storage }
+    // @ts-ignore
+    globalThis.localStorage = storage
+    localStorage.setItem('notion_token', 't')
+  })
+
+  afterEach(() => {
+    // @ts-ignore
+    delete globalThis.window
+    // @ts-ignore
+    delete globalThis.localStorage
+    vi.restoreAllMocks()
+  })
+
+  it('parses various property types', async () => {
+    const raw = {
+      id: '1',
+      created_time: '2025-06-01T00:00:00.000Z',
+      last_edited_time: '2025-06-01T00:00:00.000Z',
+      url: 'https://notion.so/page1',
+      properties: {
+        Name: { type: 'title', title: [{ plain_text: 'Sample' }] },
+        Tags: { type: 'multi_select', multi_select: [{ name: 'A' }, { name: 'B' }] },
+        Status: { type: 'status', status: { name: 'Todo' } },
+        URL: { type: 'url', url: 'https://example.com' },
+        Note: { type: 'rich_text', rich_text: [{ plain_text: 'hello' }] },
+        Created: { type: 'created_time', created_time: '2025-06-01T00:00:00.000Z' }
+      }
+    }
+
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      json: async () => ({ results: [raw] })
+    })))
+
+    const pages = await fetchDatabasePages('db')
+    expect(pages[0]).toEqual({
+      id: '1',
+      title: 'Sample',
+      keywords: [],
+      createdTime: raw.created_time,
+      lastEditedTime: raw.last_edited_time,
+      url: raw.url,
+      Tags: ['A', 'B'],
+      Status: ['Todo'],
+      URL: 'https://example.com',
+      Note: 'hello',
+      Created: raw.created_time
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- parse dynamic Notion properties like url, rich_text and created_time
- expose url field in Notion types
- unit test for fetchDatabasePages covers new property parsing

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_683ef1135ba48330a5104d8a4c685be4