### PR TITLE
Add page detail fetching

### DIFF
--- a/src/app/api/notion/page/route.ts
+++ b/src/app/api/notion/page/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const { pageId, token } = await req.json();
+
+  const res = await fetch(`https://api.notion.com/v1/pages/${pageId}`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Notion-Version": "2022-06-28",
+    },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/components/GraphPanel.tsx
+++ b/src/components/GraphPanel.tsx
@@ -81,7 +81,7 @@ export default function GraphPanel({ pages, selectedProps }: Props) {
         height={600}
         onSelectNode={setSelectedNode}
       />
-      { selectedNode && <NodeDetailPanel nodeId={selectedNode} pages={pages} />}
+      { selectedNode && <NodeDetailPanel nodeId={selectedNode} />}
       <LayoutControls {...controls} />
       <StatsPanel
         pages={pages}

--- a/src/components/NodeDetailPanel.tsx
+++ b/src/components/NodeDetailPanel.tsx
@@ -1,27 +1,35 @@
 "use client";
 import { useEffect, useState } from "react";
 import type { PageKW } from "@/lib/cytoscape/graph";
+import { fetchPageDetail } from "@/lib/notion/notionPage";
 
 interface Props {
   nodeId: string | null;
-  pages: PageKW[];
 }
 
-export default function NodeDetailPanel({ nodeId, pages }: Props) {
+export default function NodeDetailPanel({ nodeId }: Props) {
   const [detail, setDetail] = useState<PageKW | null>(null);
 
   useEffect(() => {
-    if (!nodeId) {
+    if (!nodeId || !nodeId.startsWith("p-")) {
       setDetail(null);
       return;
     }
-    if (nodeId.startsWith("p-")) {
-      const page = pages.find((p) => `p-${p.id}` === nodeId) || null;
-      setDetail(page);
-    } else {
-      setDetail(null);
-    }
-  }, [nodeId, pages]);
+
+    let cancelled = false;
+    const id = nodeId.slice(2);
+    fetchPageDetail(id)
+      .then((p) => {
+        if (!cancelled) setDetail(p as PageKW);
+      })
+      .catch(() => {
+        if (!cancelled) setDetail(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [nodeId]);
 
   return (
     <section className="flex flex-col gap-2 rounded-[var(--radius-card)] border border-n-gray bg-n-bg p-3 text-sm">

--- a/src/lib/notion/notionPage.ts
+++ b/src/lib/notion/notionPage.ts
@@ -1,0 +1,52 @@
+import { requireNotionToken } from "@/lib/notion/notionToken";
+import type { NotionPage, NotionRawPage } from "@/lib/notion/types";
+
+export async function fetchPageDetail(pageId: string): Promise<NotionPage> {
+  const token = requireNotionToken();
+
+  const res = await fetch("/api/notion/page", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ pageId, token }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(`Page fetch error: ${err.message || res.statusText}`);
+  }
+
+  const page: NotionRawPage = await res.json();
+
+  const obj: NotionPage = {
+    id: page.id,
+    title:
+      Array.isArray(page.properties.Name?.title) &&
+      page.properties.Name.title[0]?.plain_text
+        ? page.properties.Name.title[0].plain_text
+        : "Untitled",
+    createdTime: page.created_time,
+    lastEditedTime: page.last_edited_time,
+    url: page.url,
+    keywords: [],
+  };
+
+  Object.entries(page.properties).forEach(([key, prop]) => {
+    if (prop.type === "multi_select") {
+      obj[key] = (prop.multi_select as { name: string }[]).map((v) => v.name);
+    } else if (prop.type === "select" && prop.select) {
+      obj[key] = [(prop.select as { name: string }).name];
+    } else if (prop.type === "status" && prop.status) {
+      obj[key] = [(prop.status as { name: string }).name];
+    } else if (prop.type === "url" && typeof prop.url === "string") {
+      obj[key] = prop.url;
+    } else if (prop.type === "rich_text") {
+      obj[key] = (prop.rich_text as { plain_text: string }[])
+        .map((t) => t.plain_text)
+        .join("");
+    } else if (prop.type === "created_time" && prop.created_time) {
+      obj[key] = String(prop.created_time);
+    }
+  });
+
+  return obj;
+}

--- a/tests/unit/notionPage.test.ts
+++ b/tests/unit/notionPage.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { fetchPageDetail } from '@/lib/notion/notionPage'
+
+function createStorage() {
+  const store: Record<string, string> = {}
+  return {
+    setItem: (k: string, v: string) => { store[k] = v },
+    getItem: (k: string) => store[k] ?? null,
+    removeItem: (k: string) => { delete store[k] }
+  }
+}
+
+describe('fetchPageDetail', () => {
+  beforeEach(() => {
+    const storage = createStorage()
+    // @ts-ignore
+    globalThis.window = { localStorage: storage }
+    // @ts-ignore
+    globalThis.localStorage = storage
+    localStorage.setItem('notion_token', 't')
+  })
+
+  afterEach(() => {
+    // @ts-ignore
+    delete globalThis.window
+    // @ts-ignore
+    delete globalThis.localStorage
+    vi.restoreAllMocks()
+  })
+
+  it('parses various property types', async () => {
+    const raw = {
+      id: '1',
+      created_time: '2025-06-01T00:00:00.000Z',
+      last_edited_time: '2025-06-01T00:00:00.000Z',
+      url: 'https://notion.so/page1',
+      properties: {
+        Name: { type: 'title', title: [{ plain_text: 'Sample' }] },
+        Tags: { type: 'multi_select', multi_select: [{ name: 'A' }, { name: 'B' }] },
+        Status: { type: 'status', status: { name: 'Todo' } },
+        URL: { type: 'url', url: 'https://example.com' },
+        Note: { type: 'rich_text', rich_text: [{ plain_text: 'hello' }] },
+        Created: { type: 'created_time', created_time: '2025-06-01T00:00:00.000Z' }
+      }
+    }
+
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => raw
+    })))
+
+    const page = await fetchPageDetail('1')
+    expect(page).toEqual({
+      id: '1',
+      title: 'Sample',
+      keywords: [],
+      createdTime: raw.created_time,
+      lastEditedTime: raw.last_edited_time,
+      url: raw.url,
+      Tags: ['A', 'B'],
+      Status: ['Todo'],
+      URL: 'https://example.com',
+      Note: 'hello',
+      Created: raw.created_time
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- fetch page details via `/api/notion/page`
- add a Notion helper `fetchPageDetail`
- show selected page info in `NodeDetailPanel`
- update `GraphPanel` accordingly
- test page detail fetching

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_683ef4d1fb2083308d7ee9220fc5017f