### PR TITLE
Add connected node display

### DIFF
--- a/src/components/NodeDetailPanel.tsx
+++ b/src/components/NodeDetailPanel.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import type { PageKW } from "@/lib/cytoscape/graph";
 import type { GraphViewHandle } from "./GraphView";
 import type { NodeData } from "@/lib/cytoscape/types";
-import { slug } from "@/lib/cytoscape/graph";
+import { slug, getConnectedNodes } from "@/lib/cytoscape/graph";
 
 interface Props {
   nodeId: string | null;
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default function NodeDetailPanel({ nodeId, pages, viewRef }: Props) {
-  type PageDetail = { type: "page"; page: PageKW };
+  type PageDetail = { type: "page"; page: PageKW; connected: NodeData[] };
   type KeywordDetail = { type: "keyword"; keyword: string; pages: PageKW[] };
   type PropDetail = { type: "prop"; prop: string; value: string; pages: PageKW[] };
   type Detail = PageDetail | KeywordDetail | PropDetail | null;
@@ -37,7 +37,12 @@ export default function NodeDetailPanel({ nodeId, pages, viewRef }: Props) {
 
     if (node.type === "page") {
       const page = pages.find((p) => `p-${p.id}` === nodeId);
-      if (page) setDetail({ type: "page", page });
+      if (page)
+        setDetail({
+          type: "page",
+          page,
+          connected: graph ? getConnectedNodes(graph, nodeId) : [],
+        });
       else setDetail(null);
       return;
     }
@@ -82,6 +87,16 @@ export default function NodeDetailPanel({ nodeId, pages, viewRef }: Props) {
                 </li>
               ))}
           </ul>
+          {detail.connected.length > 0 && (
+            <>
+              <h3 className="mt-2 font-medium">Connected Nodes</h3>
+              <ul className="ml-4 list-disc space-y-1">
+                {detail.connected.map((n) => (
+                  <li key={n.id}>{n.label}</li>
+                ))}
+              </ul>
+            </>
+          )}
         </div>
       )}
       {detail?.type === "keyword" && (

--- a/src/lib/cytoscape/graph.ts
+++ b/src/lib/cytoscape/graph.ts
@@ -91,3 +91,22 @@ export function buildGraph(
 
   return { nodes, edges };
 }
+
+/* ─────────────────── helpers ─────────────────── */
+
+/** 指定ノードに接続するノード一覧を取得 */
+export function getConnectedNodes(
+  graph: GraphData,
+  nodeId: string
+): NodeData[] {
+  const nodeMap = new Map(graph.nodes.map((n) => [n.data.id, n.data]));
+  const connected = new Set<string>();
+  graph.edges.forEach((e) => {
+    if (e.data.source === nodeId) connected.add(e.data.target);
+    if (e.data.target === nodeId) connected.add(e.data.source);
+  });
+  return Array.from(connected)
+    .map((id) => nodeMap.get(id))
+    .filter(Boolean) as NodeData[];
+}
+

--- a/tests/unit/graph.test.ts
+++ b/tests/unit/graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { slug, buildGraph } from '@/lib/cytoscape/graph'
+import { slug, buildGraph, getConnectedNodes } from '@/lib/cytoscape/graph'
 
 const samplePages = [
   { id: '1', title: 'Page One', keywords: ['Alpha', 'Beta'], tags: ['Tag1'] },
@@ -48,5 +48,14 @@ describe('buildGraph', () => {
     const g = buildGraph(pages, { selectedProps: ['__keywords', 'tags'] })
     expect(g.nodes.length).toBe(7) // 2 pages + 3 keywords + 2 tags
     expect(g.edges.length).toBe(7) // 4 keyword edges + 3 tag edges
+  })
+})
+
+describe('getConnectedNodes', () => {
+  it('returns nodes connected to the given node id', () => {
+    const g = buildGraph(samplePages, { selectedProps: ['__keywords', 'tags'] })
+    const con = getConnectedNodes(g, 'p-1')
+    const labels = con.map((n) => n.label).sort()
+    expect(labels).toEqual(['Alpha', 'Beta', 'Tag1'])
   })
 })


### PR DESCRIPTION
## Summary
- show connected nodes in `NodeDetailPanel`
- expose `getConnectedNodes` helper in graph utils
- test connectivity helper

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_683ef230ebd883308b0b1ad71536a645