### PR TITLE
feat: color pages by status

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,6 +29,7 @@ export default function Page() {
   const [items, setItems] = useState<any[]>([]);
   const [itemsKW, setItemsKW] = useState<PageKW[] | null>(null);
   const [props, setProps] = useState<DbProperty[]>([]);
+  const [colorProp, setColorProp] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   /* ───── OAuth 認可 ───────────────────────── */
@@ -79,7 +80,11 @@ export default function Page() {
     try {
       // プロパティ
       const meta = await fetchDatabaseProperties(dbId);
-      setProps(meta.filter((p) => p.type === "multi_select" || p.type === "select"));
+      setProps(
+        meta.filter((p) => p.type === "multi_select" || p.type === "select" || p.type === "status")
+      );
+      const statusProp = meta.find((p) => p.type === "status");
+      setColorProp(statusProp ? statusProp.name : null);
 
       // ページ
       const pages = await fetchDatabasePages(dbId);
@@ -171,7 +176,9 @@ export default function Page() {
           </div>
 
           {/* Graph */}
-          {(itemsKW || items.length > 0) && <GraphPanel pages={itemsKW || items} selectedProps={selectedProps} />}
+          {(itemsKW || items.length > 0) && (
+            <GraphPanel pages={itemsKW || items} selectedProps={selectedProps} colorProp={colorProp || undefined} />
+          )}
 
           {/* Property list */}
           <details open className="rounded-lg border border-n-gray bg-white p-4 shadow-[var(--shadow-card)]">

--- a/src/components/GraphPanel.tsx
+++ b/src/components/GraphPanel.tsx
@@ -8,9 +8,9 @@ import { buildStyles } from "@/lib/cytoscape/styles";
 import type { PageKW } from "@/lib/cytoscape/graph";
 import { layouts } from "./GraphView";
 
-type Props = { pages: PageKW[]; selectedProps: string[] };
+type Props = { pages: PageKW[]; selectedProps: string[]; colorProp?: string };
 
-export default function GraphPanel({ pages, selectedProps }: Props) {
+export default function GraphPanel({ pages, selectedProps, colorProp }: Props) {
   const viewRef = useRef<GraphViewHandle | null>(null);
   const [layout, setLayout] = useState<keyof typeof layouts>("cose-bilkent");
   const [version, setVersion] = useState(0);
@@ -74,6 +74,7 @@ export default function GraphPanel({ pages, selectedProps }: Props) {
         ref={viewRef}
         pages={pages}
         selectedProps={selectedProps}
+        colorProp={colorProp}
         layoutName={layout}
         stylesheet={stylesheet}
         height={600}

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -53,6 +53,8 @@ type Props = {
   pages: PageKW[];
   /** 選択されたプロパティ名の配列 */
   selectedProps?: string[];
+  /** ページ色分けに使うプロパティ名 */
+  colorProp?: string;
   /** レイアウト名 （例: "cose" "fcose" など）*/
   layoutName?: LayoutName;
   /** グラフ高さ */
@@ -74,10 +76,13 @@ export interface GraphViewHandle {
 }
 
 const GraphView = forwardRef<GraphViewHandle, Props>(
-  ({ pages, selectedProps = [], layoutName = "cose", height = 600, stylesheet }, ref) => {
+  (
+    { pages, selectedProps = [], colorProp, layoutName = "cose", height = 600, stylesheet },
+    ref
+  ) => {
     const { nodes, edges } = useMemo(
-      () => buildGraph(pages, { selectedProps }),
-      [pages, selectedProps]
+      () => buildGraph(pages, { selectedProps, colorProp }),
+      [pages, selectedProps, colorProp]
     );
     const cyRef = useRef<cytoscape.Core | null>(null);
 

--- a/src/lib/cytoscape/graph.ts
+++ b/src/lib/cytoscape/graph.ts
@@ -7,6 +7,8 @@ export interface PageKW extends Record<string, any> {
   id: string;
   title: string;
   keywords: string[];
+  /** select/status の色マップ */
+  __propColors?: Record<string, string>;
 }
 
 /* ─────────────────── utils ─────────────────── */
@@ -24,11 +26,30 @@ const PID = "p-";
 const KID = "k-";
 const PVID = "pv-";
 
+const colorMap: Record<string, string> = {
+  default: "var(--color-n-gray-bg)",
+  gray: "var(--color-n-gray-bg)",
+  brown: "var(--color-n-brown-bg)",
+  orange: "var(--color-n-orange-bg)",
+  yellow: "var(--color-n-yellow-bg)",
+  green: "var(--color-n-green-bg)",
+  blue: "var(--color-n-blue-bg)",
+  purple: "var(--color-n-purple-bg)",
+  pink: "var(--color-n-pink-bg)",
+  red: "var(--color-n-red-bg)",
+};
+
+const DEFAULT_PAGE_COLOR = colorMap.blue;
+
+const notionColorToCss = (c?: string) => colorMap[c ?? ""] ?? colorMap.default;
+
 /* ─────────────────── main builder ─────────────────── */
 
 export interface BuildOptions {
   /** グラフに含めたい multi_select / select プロパティ名 */
   selectedProps?: string[];
+  /** ページの色分けに使う select/status プロパティ名 */
+  colorProp?: string;
 }
 
 /**
@@ -36,7 +57,7 @@ export interface BuildOptions {
  */
 export function buildGraph(
   pages: PageKW[],
-  { selectedProps = [] }: BuildOptions = {}
+  { selectedProps = [], colorProp }: BuildOptions = {}
 ): GraphData {
   const nodes: GraphData["nodes"] = [];
   const edges: GraphData["edges"] = [];
@@ -54,7 +75,9 @@ export function buildGraph(
 
   pages.forEach((page) => {
     const pageId = PID + page.id;
-    pushNode({ id: pageId, label: page.title, type: "page" });
+    const colorName = colorProp ? page.__propColors?.[colorProp] : undefined;
+    const color = colorName ? notionColorToCss(colorName) : DEFAULT_PAGE_COLOR;
+    pushNode({ id: pageId, label: page.title, type: "page", color });
 
     /* --- キーワード --- */
     if (includeKw) {

--- a/src/lib/cytoscape/styles.ts
+++ b/src/lib/cytoscape/styles.ts
@@ -37,7 +37,7 @@ export const buildStyles = ({
   {
     selector: 'node[type="page"]',
     style: {
-      "background-color": tokens.pageFill,
+      "background-color": "data(color)",
       opacity: 0.8,
       color: tokens.pageText,
       width: 60,

--- a/src/lib/cytoscape/types.ts
+++ b/src/lib/cytoscape/types.ts
@@ -6,6 +6,8 @@ export interface NodeData {
   type: NodeKind;
   /** prop ノードのみ保持 (e.g. "Tags") */
   propName?: string;
+  /** ノード背景色 (CSS var) */
+  color?: string;
 }
 export interface EdgeData {
   id: string;

--- a/src/lib/notion/notionDatabase.ts
+++ b/src/lib/notion/notionDatabase.ts
@@ -25,17 +25,24 @@ export async function fetchDatabasePages(dbId: string): Promise<PageKW[]> {
       createdTime: page.created_time,
       lastEditedTime: page.last_edited_time,
     };
+    const colorMap: Record<string, string> = {};
 
     /* すべての multi_select / select / status を走査して配列化 */
     Object.entries(page.properties).forEach(([key, prop]: [string, any]) => {
       if (prop.type === "multi_select") {
         obj[key] = prop.multi_select.map((v: any) => v.name);
+        // multi_select は色をページ側には持たない
       }
       if (prop.type === "select" && prop.select) {
-        obj[key] = [prop.select.name]; // select は単一なので配列化
+        obj[key] = [prop.select.name];
+        colorMap[key] = prop.select.color;
+      }
+      if (prop.type === "status" && prop.status) {
+        obj[key] = [prop.status.name];
+        colorMap[key] = prop.status.color;
       }
     });
 
-    return obj as PageKW;
+    return { ...(obj as PageKW), __propColors: colorMap };
   });
 }

--- a/tests/unit/graph.test.ts
+++ b/tests/unit/graph.test.ts
@@ -49,4 +49,14 @@ describe('buildGraph', () => {
     expect(g.nodes.length).toBe(7) // 2 pages + 3 keywords + 2 tags
     expect(g.edges.length).toBe(7) // 4 keyword edges + 3 tag edges
   })
+
+  it('applies page color via colorProp', () => {
+    const pages = [
+      { id: '1', title: 'First', keywords: [], __propColors: { Status: 'red' } },
+      { id: '2', title: 'Second', keywords: [], __propColors: { Status: 'blue' } },
+    ] as any
+    const g = buildGraph(pages, { colorProp: 'Status' })
+    expect(g.nodes.find(n => n.data.id === 'p-1')?.data.color).toBe('var(--color-n-red-bg)')
+    expect(g.nodes.find(n => n.data.id === 'p-2')?.data.color).toBe('var(--color-n-blue-bg)')
+  })
 })


### PR DESCRIPTION
## Summary
- add page colour mapping by status/select property
- support colorProp option throughout graph build and components
- persist status colours when fetching pages
- display graph with hue per page
- test coloring logic

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_683eed984a04833090b637ca231a8834