### PR TITLE
feature/2025-06-04-color-legend

### DIFF
--- a/src/components/ColorLegend.tsx
+++ b/src/components/ColorLegend.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useMemo } from "react";
+import type { PageKW } from "@/lib/cytoscape/graph";
+import { computeColorMap } from "@/lib/cytoscape/graph";
+
+interface Props {
+  pages: PageKW[];
+  colorProp?: string;
+}
+
+export default function ColorLegend({ pages, colorProp }: Props) {
+  const map = useMemo(() => computeColorMap(pages, colorProp), [pages, colorProp]);
+
+  if (!colorProp || map.size === 0) return null;
+
+  return (
+    <div className="absolute right-2 top-2 rounded-[var(--radius-card)] border border-n-gray bg-white p-2 text-xs shadow-[var(--shadow-card)]">
+      <div className="mb-1 font-medium">{colorProp}</div>
+      <ul className="space-y-1">
+        {[...map.entries()].map(([val, color]) => (
+          <li key={val} className="flex items-center gap-1">
+            <span
+              className="inline-block h-3 w-3 rounded-full border"
+              style={{ backgroundColor: color }}
+            />
+            <span>{val}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/GraphPanel.tsx
+++ b/src/components/GraphPanel.tsx
@@ -5,6 +5,7 @@ import LayoutControls from "./LayoutControls";
 import StatsPanel from "./StatsPanel";
 import NodeListPanel from "./NodeListPanel";
 import NodeDetailPanel from "./NodeDetailPanel";
+import ColorLegend from "./ColorLegend";
 import { buildStyles } from "@/lib/cytoscape/styles";
 import type { PageKW } from "@/lib/cytoscape/graph";
 import { layouts } from "./GraphView";
@@ -72,16 +73,19 @@ export default function GraphPanel({ pages, selectedProps, colorProp }: Props) {
   return (
     <section className="flex flex-col gap-3 bg-white border border-n-gray rounded-[var(--radius-card)] p-3">
       
-      <GraphView
-        ref={viewRef}
-        pages={pages}
-        selectedProps={selectedProps}
-        colorProp={colorProp}
-        layoutName={layout}
-        stylesheet={stylesheet}
-        height={600}
-        onSelectNode={setSelectedNode}
-      />
+      <div className="relative">
+        <GraphView
+          ref={viewRef}
+          pages={pages}
+          selectedProps={selectedProps}
+          colorProp={colorProp}
+          layoutName={layout}
+          stylesheet={stylesheet}
+          height={600}
+          onSelectNode={setSelectedNode}
+        />
+        <ColorLegend pages={pages} colorProp={colorProp} />
+      </div>
       {selectedNode && (
         <NodeDetailPanel nodeId={selectedNode} pages={pages} viewRef={viewRef} />
       )}

--- a/src/components/GraphPanel.tsx
+++ b/src/components/GraphPanel.tsx
@@ -21,6 +21,7 @@ export default function GraphPanel({ pages, selectedProps, colorProp }: Props) {
   /* トグル用 state（お好みで拡張） */
   const [showNodeLabels, setShowNodeLabels] = useState(true);
   const [showEdgeLabels, setShowEdgeLabels] = useState(false);
+  const [showColorLegend, setShowColorLegend] = useState(true);
 
   // @ts-expect-error, Cytoscape has no type definition for this
   const [stylesheet, setStylesheet] = useState<cytoscape.Stylesheet[]>(
@@ -64,8 +65,10 @@ export default function GraphPanel({ pages, selectedProps, colorProp }: Props) {
     },
     showEdgeLabels,
     showNodeLabels,
+    showColorLegend,
     onToggleEdgeLabels: () => setShowEdgeLabels((s) => !s),
     onToggleNodeLabels: () => setShowNodeLabels((s) => !s),
+    onToggleColorLegend: () => setShowColorLegend((s) => !s),
   };
       
   const handleNodeDelete = () => setVersion((v) => v + 1);
@@ -84,7 +87,9 @@ export default function GraphPanel({ pages, selectedProps, colorProp }: Props) {
           height={600}
           onSelectNode={setSelectedNode}
         />
-        <ColorLegend pages={pages} colorProp={colorProp} />
+        {showColorLegend && (
+          <ColorLegend pages={pages} colorProp={colorProp} />
+        )}
       </div>
       {selectedNode && (
         <NodeDetailPanel nodeId={selectedNode} pages={pages} viewRef={viewRef} />

--- a/src/components/LayoutControls.tsx
+++ b/src/components/LayoutControls.tsx
@@ -34,8 +34,10 @@ type Props = {
   onExportJson: () => void;
   showEdgeLabels: boolean;
   showNodeLabels: boolean;
+  showColorLegend: boolean;
   onToggleEdgeLabels: () => void;
   onToggleNodeLabels: () => void;
+  onToggleColorLegend: () => void;
 };
 
 export default function LayoutControls({
@@ -48,8 +50,10 @@ export default function LayoutControls({
   onExportJson,
   showEdgeLabels,
   showNodeLabels,
+  showColorLegend,
   onToggleEdgeLabels,
   onToggleNodeLabels,
+  onToggleColorLegend,
 }: Props) {
   const [collapsed, setCollapsed] = useState(false);
 
@@ -137,6 +141,9 @@ export default function LayoutControls({
             </button>
             <button onClick={onToggleNodeLabels} className={toggleBtn(showNodeLabels)}>
               {showNodeLabels ? <Eye size={14} /> : <EyeOff size={14} />} Node Labels
+            </button>
+            <button onClick={onToggleColorLegend} className={toggleBtn(showColorLegend)}>
+              {showColorLegend ? <Eye size={14} /> : <EyeOff size={14} />} Legend
             </button>
           </div>
         </>

--- a/tests/unit/graph.test.ts
+++ b/tests/unit/graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { slug, buildGraph, getConnectedNodes } from '@/lib/cytoscape/graph'
+import { slug, buildGraph, getConnectedNodes, computeColorMap } from '@/lib/cytoscape/graph'
 
 const samplePages = [
   { id: '1', title: 'Page One', keywords: ['Alpha', 'Beta'], tags: ['Tag1'] },
@@ -70,5 +70,21 @@ describe('getConnectedNodes', () => {
     const con = getConnectedNodes(g, 'p-1')
     const labels = con.map((n) => n.label).sort()
     expect(labels).toEqual(['Alpha', 'Beta', 'Tag1'])
+  })
+})
+
+describe('computeColorMap', () => {
+  it('returns consistent colors for property values', () => {
+    const pages = [
+      { id: '1', title: 'First', keywords: [], status: ['Todo'] },
+      { id: '2', title: 'Second', keywords: [], status: ['Done'] },
+      { id: '3', title: 'Third', keywords: [], status: ['Todo'] },
+    ]
+    const map = computeColorMap(pages, 'status')
+    const graph = buildGraph(pages, { colorProp: 'status' })
+    const todoColor = map.get('Todo')
+    const nodeColor = graph.nodes.find(n => n.data.label === 'First')?.data.color
+    expect(todoColor).toBe(nodeColor)
+    expect(map.size).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary
- compute color maps for page coloring
- overlay `ColorLegend` component on graph panel
- expose new helper and test it

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683f9ff9fdf08330a531fa59968c7be0